### PR TITLE
Adding Modifier Composition API

### DIFF
--- a/Examples/HeroExamples.xcodeproj/project.pbxproj
+++ b/Examples/HeroExamples.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		55F29A161E1D5FF0005959AF /* HeroComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F29A151E1D5FF0005959AF /* HeroComposition.swift */; };
 		83043017B73BC66DBB920D5C /* Pods_HeroExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEE340F89FF0A49DD23A5A6E /* Pods_HeroExamples.framework */; };
 		A304BF841DF2717900A03345 /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A304BF831DF2717900A03345 /* ImageViewController.swift */; };
 		A304BF8A1DF647FC00A03345 /* ImageCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = A304BF891DF647FC00A03345 /* ImageCells.swift */; };
@@ -85,6 +86,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		55F29A151E1D5FF0005959AF /* HeroComposition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeroComposition.swift; path = ../../Hero/HeroComposition.swift; sourceTree = "<group>"; };
 		5CD4F09A588E81DA75C2BE38 /* Pods-HeroExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeroExamples.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HeroExamples/Pods-HeroExamples.debug.xcconfig"; sourceTree = "<group>"; };
 		A304BF831DF2717900A03345 /* ImageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageViewController.swift; path = ImageGallery/ImageViewController.swift; sourceTree = "<group>"; };
 		A304BF891DF647FC00A03345 /* ImageCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageCells.swift; path = ImageGallery/ImageCells.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 			isa = PBXGroup;
 			children = (
 				A306D3C51E1C7A3C00B6C23A /* Hero.swift */,
+				55F29A151E1D5FF0005959AF /* HeroComposition.swift */,
 				A306D3C61E1C7A3C00B6C23A /* HeroContext.swift */,
 				A306D3CC1E1C7A3C00B6C23A /* HeroPlugin.swift */,
 				A306D3CD1E1C7A3C00B6C23A /* HeroTypes.swift */,
@@ -539,6 +542,7 @@
 				A306D3D51E1C7A3C00B6C23A /* CG+Hero.swift in Sources */,
 				A306D3E11E1C7A3C00B6C23A /* SourceIDPreprocessor.swift in Sources */,
 				A306D3D81E1C7A3C00B6C23A /* Hero.swift in Sources */,
+				55F29A161E1D5FF0005959AF /* HeroComposition.swift in Sources */,
 				A306D3E31E1C7A3C00B6C23A /* UIKit+HeroModifier.swift in Sources */,
 				A306D3D61E1C7A3C00B6C23A /* ClearPreprocessor.swift in Sources */,
 				A306D3D71E1C7A3C00B6C23A /* DispatchQueue+Hero.swift in Sources */,

--- a/Examples/HeroExamples/Examples/CityGuide/CityGuideViewController.swift
+++ b/Examples/HeroExamples/Examples/CityGuide/CityGuideViewController.swift
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 import UIKit
+import Hero
 
 class CityGuideViewController: UIViewController {
   @IBOutlet weak var collectionView: UICollectionView!
@@ -36,7 +37,7 @@ class CityGuideViewController: UIViewController {
           indexPath != currentCellIndex {
           let beforeCurrentCell = indexPath < currentCellIndex
           // want right side cells to slide right, and left side cells to slide left
-          cell.heroModifiers = "fade translate(\(beforeCurrentCell ? -100 : 100),0)"
+          cell.heroModifiers = HeroComposition().fade().translate(x: beforeCurrentCell ? -100 : 100, y: 0).modifier
         }
       }
     }

--- a/Examples/HeroExamples/Examples/ImageGallery/ImageGalleryCollectionViewController.swift
+++ b/Examples/HeroExamples/Examples/ImageGallery/ImageGalleryCollectionViewController.swift
@@ -59,7 +59,7 @@ extension ImageGalleryViewController:UICollectionViewDataSource{
     let imageCell = collectionView.dequeueReusableCell(withReuseIdentifier: "item", for: indexPath) as! ImageCell
     imageCell.imageView.image = UIImage(named: "Unsplash\(indexPath.item % 10)_thumb")
     imageCell.heroID = "image_\(indexPath.item)"
-    imageCell.heroModifiers = "fade translate(0, 150) rotate(-1,0,0) scale(0.8) zPosition(50) zPositionIfMatched(100)"
+    imageCell.heroModifiers = HeroComposition().fade().translate(x: 0, y: 150).rotate(x: -1, y: 0, z: 0).scale(s: 0.8).zPosition(z: 50).zPositionIfMatched(z: 100).modifier
     return imageCell
   }
 }

--- a/Hero/HeroComposition.swift
+++ b/Hero/HeroComposition.swift
@@ -1,0 +1,189 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Luke Zhao <me@lkzhao.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+/**
+ A composable interface for building a string of hero modifiers
+ Creating a HeroComposition allows you to chain modifiers to build your animation string
+ Extract the modifier string using the .modifier attribute after composing your animation
+ 
+ To create a simple fade and position animation:
+ 
+ HeroComposition().fade().position(0,90).modifier
+ 
+ To create a more complex animation:
+ 
+ HeroComposition().fade().translate(0,150).rotate(-1,0,0).scale(0.8).zPosition(50).zPositionIfMatched(100).modifier
+ 
+ For more documentation on using modifiers, visit:
+ 
+ https://github.com/lkzhao/Hero/wiki/Usage-Guide
+ 
+ */
+public class HeroComposition {
+    /**
+     - Returns: the modifier string for the composition
+     */
+    fileprivate(set) public var modifier = ""
+    
+    fileprivate func addModifier(text:String) {
+        if modifier.characters.count != 0 {
+            modifier += " "
+        }
+        
+        modifier += text
+    }
+    
+    public init() {
+        
+    }
+}
+
+// Basic Modifiers
+public extension HeroComposition {
+    func fade() -> HeroComposition {
+        addModifier(text: "fade")
+        return self
+    }
+    
+    func position(x:Float, y:Float) -> HeroComposition {
+        addModifier(text: "position(" + String(x) + "," + String(y) + ")")
+        return self
+    }
+    
+    func size(w:Float, h:Float) -> HeroComposition {
+        addModifier(text: "size(" + String(w) + "," + String(h) + ")")
+        return self
+    }
+    
+    func scale(s:Float) -> HeroComposition {
+        addModifier(text: "scale(" + String(s) + ")")
+        return self
+    }
+    
+    func scale(w:Float, h:Float) -> HeroComposition {
+        addModifier(text: "scale(" + String(w) + "," + String(h) + ")")
+        return self
+    }
+    
+    func rotate(z:Float) -> HeroComposition {
+        addModifier(text: "rotate(" + String(z) + ")")
+        return self
+    }
+    
+    func rotate(x:Float, y:Float, z:Float) -> HeroComposition {
+        addModifier(text: "rotate(" + String(x) + "," + String(y) + "," + String(z) + ")")
+        return self
+    }
+    
+    func perspective(z:Float) -> HeroComposition {
+        addModifier(text: "perspective(" + String(z) + ")")
+        return self
+    }
+    
+    func translate(x:Float, y:Float) -> HeroComposition {
+        addModifier(text: "translate(" + String(x) + "," + String(y) + ")")
+        return self
+    }
+    
+    func translate(x:Float, y:Float, z:Float) -> HeroComposition {
+        addModifier(text: "translate(" + String(x) + "," + String(y) + "," + String(z) + ")")
+        return self
+    }
+}
+
+public enum HeroCascadeDirection:String {
+    case topToBottom
+    case bottomToTop
+    case leftToRight
+    case rightToLeft
+}
+
+public enum HeroCurveName:String {
+    case linear
+    case easeIn
+    case easeOut
+    case easeInOut
+    case standard
+    case deceleration
+    case acceleration
+    case sharp
+}
+
+// Advanced Modifiers
+public extension HeroComposition {
+    func delay(t:Float) -> HeroComposition {
+        addModifier(text: "delay(" + String(t) + ")")
+        return self
+    }
+    
+    func duration(t:Float) -> HeroComposition {
+        addModifier(text: "duration(" + String(t) + ")")
+        return self
+    }
+    
+    func curve(name:HeroCurveName) -> HeroComposition {
+        addModifier(text: "curve(" + name.rawValue + ")")
+        return self
+    }
+    
+    func curve(c1x:Float, c1y:Float, c2x:Float, c2y:Float) -> HeroComposition {
+        addModifier(text: "curve(" + String(c1x) + "," + String(c1y) + "," + String(c2x) + "," + String(c2y) + ")")
+        return self
+    }
+    
+    func spring(stiffness:Float, damping:Float) -> HeroComposition {
+        addModifier(text: "spring(" + String(stiffness) + "," + String(damping) + ")")
+        return self
+    }
+    
+    func zPosition(z:Float) -> HeroComposition {
+        addModifier(text: "zPosition(" + String(z) + ")")
+        return self
+    }
+    
+    func zPositionIfMatched(z:Float) -> HeroComposition {
+        addModifier(text: "zPositionIfMatched(" + String(z) + ")")
+        return self
+    }
+    
+    func sourceID(from:String) -> HeroComposition {
+        addModifier(text: "sourceID(" + from + ")")
+        return self
+    }
+    
+    func arc(intensity:Float = 1) -> HeroComposition {
+        addModifier(text: "arc(" + String(intensity) + ")")
+        return self
+    }
+    
+    func cascade(deltaDelay:Float, direction:HeroCascadeDirection = .topToBottom, initialDelay:Float = 0, forceMatchedToWait:Bool = false) -> HeroComposition {
+        addModifier(text: "cascade(" + String(deltaDelay) + "," + direction.rawValue + "," + String(initialDelay) + "," + String(forceMatchedToWait) + ")")
+        return self
+    }
+    
+    func clearSubviewModifiers() -> HeroComposition {
+        addModifier(text: "clearSubviewModifiers")
+        return self
+    }
+}


### PR DESCRIPTION
I’m adding a modifier composition API to build hero modifier animation strings using method chaining. The idea is to create a compiled method for creating an animation. There are a lot of benefits to this:

- Ease of use. It’s a lot easier to build animation strings using autocomplete. It’s easy to see all of the available modifier options for use in an animation.

- You don’t have to remember or debug syntax. The composition does that for you.

- It’s a great foundation to build on for the future. Using this type of interface you can build modifier validation and other features (including pre-fabricated or reusable animations).

- It’s pretty scalable. All you have to do is add another method when you support more animation modifiers.

- It will also work with HeroID tags to specific views. You can pass views as parameters and use their HeroIDs to construct the appropriate animation string.

Basically, I love the idea of Hero. But the string syntax for constructing modifiers was making it harder for me to use. This keeps the flexible string syntax while adding a composition interface that’s more discoverable, safer, and easier to use.