### PR TITLE
Removed duplicated case for zPosition modifier

### DIFF
--- a/Hero/HeroModifier.swift
+++ b/Hero/HeroModifier.swift
@@ -57,10 +57,6 @@ public class HeroModifier {
       modifier = .translate(x: parameters.getCGFloat(0) ?? 0,
                             y: parameters.getCGFloat(1) ?? 0,
                             z: parameters.getCGFloat(2) ?? 0)
-    case "zPosition":
-      if let zPosition = parameters.getCGFloat(0){
-        modifier = .zPosition(zPosition)
-      }
     case "duration":
       if let duration = parameters.getDouble(0){
         modifier = .duration(duration)


### PR DESCRIPTION
The switch case for `zPosition` modifier is defined 2 times at lines 60 and 98. Just removed one of them.