### PR TITLE
Added large_tuple to list of disabled SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,7 @@ disabled_rules: # rule identifiers to exclude from running
   - cyclomatic_complexity
   - function_body_length
   - todo
+  - large_tuple
 
 opt_in_rules: # some rules are only opt-in
   - empty_count


### PR DESCRIPTION
Currently, this computed property:
`var components:(r:CGFloat, g: CGFloat, b: CGFloat, a: CGFloat)`
returns a tuple of more than 3 members, causing SwiftLint to fail the build. I've made a small change to relax the SwiftLint rules.