### PR TITLE
fix warning 'M_PI is deprecated' in Swift 3.1

### DIFF
--- a/Sources/CG+Hero.swift
+++ b/Sources/CG+Hero.swift
@@ -22,7 +22,7 @@
 
 import MetalKit
 
-let π = CGFloat(M_PI)
+let π = CGFloat.pi
 
 internal struct KeySet<Key:Hashable, Value:Hashable> {
   var dict: [Key:Set<Value>] = [:]

--- a/Sources/HeroDebugView.swift
+++ b/Sources/HeroDebugView.swift
@@ -50,7 +50,7 @@ class HeroDebugView: UIView {
   }
 
   var showOnTop: Bool = false
-  var rotation: CGFloat = CGFloat.pi / 6
+  var rotation: CGFloat = π / 6
   var scale: CGFloat = 0.6
   var translation: CGPoint = .zero
   var progress: Float {
@@ -139,10 +139,10 @@ class HeroDebugView: UIView {
       startRotation = rotation
     }
     rotation = startRotation + panGR.translation(in: nil).x / 150
-    if rotation > CGFloat.pi {
-      rotation -= 2 * CGFloat.pi
-    } else if rotation < -CGFloat.pi {
-      rotation += 2 * CGFloat.pi
+    if rotation > π {
+      rotation -= 2 * π
+    } else if rotation < -π {
+      rotation += 2 * π
     }
     delegate?.onPerspectiveChanged(translation:translation, rotation: rotation, scale:scale)
   }

--- a/Sources/HeroDebugView.swift
+++ b/Sources/HeroDebugView.swift
@@ -50,7 +50,7 @@ class HeroDebugView: UIView {
   }
 
   var showOnTop: Bool = false
-  var rotation: CGFloat = CGFloat(M_PI / 6)
+  var rotation: CGFloat = CGFloat.pi / 6
   var scale: CGFloat = 0.6
   var translation: CGPoint = .zero
   var progress: Float {
@@ -139,10 +139,10 @@ class HeroDebugView: UIView {
       startRotation = rotation
     }
     rotation = startRotation + panGR.translation(in: nil).x / 150
-    if rotation > CGFloat(M_PI) {
-      rotation -= CGFloat(2 * M_PI)
-    } else if rotation < -CGFloat(M_PI) {
-      rotation += CGFloat(2 * M_PI)
+    if rotation > CGFloat.pi {
+      rotation -= 2 * CGFloat.pi
+    } else if rotation < -CGFloat.pi {
+      rotation += 2 * CGFloat.pi
     }
     delegate?.onPerspectiveChanged(translation:translation, rotation: rotation, scale:scale)
   }


### PR DESCRIPTION
 M_PI is deprecated in Swift 3.1