### PR TITLE
Swift 4 Package compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,15 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "Hero"
+    name: "Hero",
+    products: [
+        .library(name: "Hero",  targets: ["Hero"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "Hero", path: "Sources")
+    ]
 )

--- a/Sources/Transition/HeroProgressRunner.swift
+++ b/Sources/Transition/HeroProgressRunner.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 protocol HeroProgressRunnerDelegate: class {
   func updateProgress(progress: Double)

--- a/Sources/Transition/HeroTransition+Complete.swift
+++ b/Sources/Transition/HeroTransition+Complete.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 extension HeroTransition {
   open func complete(finished: Bool) {

--- a/Sources/Transition/HeroTransition+CustomTransition.swift
+++ b/Sources/Transition/HeroTransition+CustomTransition.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 // custom transition helper, used in hero_replaceViewController
 public extension HeroTransition {

--- a/Sources/Transition/HeroTransition+Interactive.swift
+++ b/Sources/Transition/HeroTransition+Interactive.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 extension HeroTransition {
   /**

--- a/Sources/Transition/HeroTransition+Start.swift
+++ b/Sources/Transition/HeroTransition+Start.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 extension HeroTransition {
   open func start() {


### PR DESCRIPTION
I've been trying to import Hero into a Swift 4 project using [this approach](https://github.com/j-channings/swift-package-manager-ios). It mostly works, but some UIKit imports are missing, and the Source tree layout doesn't match what SPM 4 expects.

This PR fixes it for Swift 4, but I don't know if SPM 3 will work any more. I haven't tested whether it worked previously; was anybody else using it? I can put in a Package@Swift-3.swift for backwards compatibility if it's needed.