### PR TITLE
Fix overlay layer animation bug

### DIFF
--- a/Sources/Animator/HeroCoreAnimationViewContext.swift
+++ b/Sources/Animator/HeroCoreAnimationViewContext.swift
@@ -96,7 +96,7 @@ internal class HeroCoreAnimationViewContext: HeroAnimatorViewContext {
 
   func currentValue(key: String) -> Any? {
     if let key = overlayKeyFor(key: key) {
-      return overlayLayer?.value(forKeyPath: key)
+      return (overlayLayer?.presentation() ?? overlayLayer)?.value(forKeyPath: key)
     }
     if snapshot.layer.animationKeys()?.isEmpty != false {
       return snapshot.layer.value(forKeyPath:key)


### PR DESCRIPTION
Fixes Issue #303. When resuming interactive transition Hero couldn't obtain the actual opacity & background value for overlay layer. Need to use presentation layer instead of actual layer.