### PR TITLE
Changes observeForProgressUpdate protection level to public, instead of internal

### DIFF
--- a/Sources/Transition/HeroTransition.swift
+++ b/Sources/Transition/HeroTransition.swift
@@ -190,7 +190,7 @@ open class HeroTransition: NSObject {
    - Parameters:
    - observer: the observer
    */
-  func observeForProgressUpdate(observer: HeroProgressUpdateObserver) {
+  public func observeForProgressUpdate(observer: HeroProgressUpdateObserver) {
     if progressUpdateObservers == nil {
       progressUpdateObservers = []
     }


### PR DESCRIPTION
This PR is intended to allow classes outside of the Hero module to call `observeForProgressUpdate(observer:)`, which is not possible at the moment since it's protection level is set to `internal` by default.

See issue #328 for more information.