### PR TITLE
Prevents UITabBarController animation from being fired multiple times

### DIFF
--- a/Sources/Transition/HeroTransition+UITabBarControllerDelegate.swift
+++ b/Sources/Transition/HeroTransition+UITabBarControllerDelegate.swift
@@ -24,6 +24,9 @@ import UIKit
 
 extension HeroTransition: UITabBarControllerDelegate {
   public func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+    guard tabBarController.selectedViewController !== viewController else {
+      return false
+    }
     if isTransitioning {
       cancel(animate: false)
     }


### PR DESCRIPTION
Prevents UITabBarController animation from being fired multiple times when new tab is pressed rapidly.