### PR TITLE
Fix small typo on City Guide Example

### DIFF
--- a/Examples/Examples/CityGuide/CityGuide.storyboard
+++ b/Examples/Examples/CityGuide/CityGuide.storyboard
@@ -105,7 +105,7 @@
                                     <outlet property="delegate" destination="Tnf-dk-9EF" id="GRM-bK-W0x"/>
                                 </connections>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Advanture awaits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LCG-7f-btr">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Adventure awaits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LCG-7f-btr">
                                 <rect key="frame" x="24" y="84" width="251" height="44"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="32"/>
                                 <color key="textColor" red="0.25490196079999999" green="0.28627450980000002" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
'Advanture' -> 'Adventure'