### PR TITLE
Add UIView+Hero.swift and UIViewController+Hero.swift to public headers

### DIFF
--- a/Hero.xcodeproj/project.pbxproj
+++ b/Hero.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		2D1F7FE71E49DD90004D944B /* TVImageGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F7FE61E49DD90004D944B /* TVImageGalleryViewController.swift */; };
 		2D1F7FEA1E49DD90004D944B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2D1F7FE81E49DD90004D944B /* Main.storyboard */; };
 		2D1F7FF21E49E043004D944B /* Hero.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D1F7FBF1E49DCB5004D944B /* Hero.framework */; };
+		3676E7E32059525F0003B9DF /* UIView+Hero.swift in Headers */ = {isa = PBXBuildFile; fileRef = B101B2C91E561408007E7112 /* UIView+Hero.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		3676E7E4205952620003B9DF /* UIViewController+Hero.swift in Headers */ = {isa = PBXBuildFile; fileRef = B101B2CD1E561421007E7112 /* UIViewController+Hero.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		3676E7E5205952690003B9DF /* UIView+Hero.swift in Headers */ = {isa = PBXBuildFile; fileRef = B101B2C91E561408007E7112 /* UIView+Hero.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		3676E7E62059526B0003B9DF /* UIViewController+Hero.swift in Headers */ = {isa = PBXBuildFile; fileRef = B101B2CD1E561421007E7112 /* UIViewController+Hero.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		5C5442AA2004092500E1E326 /* HeroCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C69728F2002CDBD001A5051 /* HeroCompatible.swift */; };
 		5C6972902002CDBD001A5051 /* HeroCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C69728F2002CDBD001A5051 /* HeroCompatible.swift */; };
 		83043017B73BC66DBB920D5C /* Pods_HeroExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEE340F89FF0A49DD23A5A6E /* Pods_HeroExamples.framework */; };
@@ -641,6 +645,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D1F7FDC1E49DD3C004D944B /* Hero.h in Headers */,
+				3676E7E5205952690003B9DF /* UIView+Hero.swift in Headers */,
+				3676E7E62059526B0003B9DF /* UIViewController+Hero.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -649,6 +655,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A306D3B61E1C7A2E00B6C23A /* Hero.h in Headers */,
+				3676E7E32059525F0003B9DF /* UIView+Hero.swift in Headers */,
+				3676E7E4205952620003B9DF /* UIViewController+Hero.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
... to allow Interface Builder to render live views and see `@IBInpectables`

This fixes #307

<img width="967" alt="fixes carthage live views" src="https://user-images.githubusercontent.com/7915553/37404312-6999e5ae-2789-11e8-8542-69dd9d44be3b.png">
