### PR TITLE
[Core] Providing completion for very basic handlers

### DIFF
--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -205,11 +205,11 @@ public extension HeroExtension where Base: UIViewController {
    Dismiss the current view controller with animation. Will perform a navigationController.popViewController
    if the current view controller is contained inside a navigationController
    */
-  public func dismissViewController() {
+  public func dismissViewController(completion: (() -> Void)? = nil) {
     if let navigationController = base.navigationController, navigationController.viewControllers.first != base {
       navigationController.popViewController(animated: true)
     } else {
-      base.dismiss(animated: true, completion: nil)
+      base.dismiss(animated: true, completion: completion)
     }
   }
 
@@ -295,7 +295,7 @@ public extension HeroExtension where Base: UIViewController {
   /**
    Replace the current view controller with another VC on the navigation/modal stack.
    */
-  public func replaceViewController(with next: UIViewController) {
+  public func replaceViewController(with next: UIViewController, completion: (() -> Void)? = nil) {
     let hero = next.transitioningDelegate as? HeroTransition ?? Hero.shared
 
     if hero.isTransitioning {
@@ -321,7 +321,7 @@ public extension HeroExtension where Base: UIViewController {
         next.view.window?.addSubview(next.view)
         if let parentVC = parentVC {
           base.dismiss(animated: false) {
-            parentVC.present(next, animated: false, completion: nil)
+            parentVC.present(next, animated: false, completion: completion)
           }
         } else {
           UIApplication.shared.keyWindow?.rootViewController = next


### PR DESCRIPTION
In some cases, I have felt the need to override some of the completion blocks.
This requires me to provide the completion block as part of the helper function itself.

I also wanted to provide another parameter for `unwindToViewController` but given how its being used in the current framework and possible external usages, its going to break every single flow.